### PR TITLE
아이콘이 곁들여진 인풋 컴포넌트 추가

### DIFF
--- a/src/components/IconInput.js
+++ b/src/components/IconInput.js
@@ -1,0 +1,43 @@
+import { Colors } from '../styles';
+import { Icon } from 'react-bulma-components';
+import styled from '@emotion/styled';
+
+const IconInput = ({
+  type,
+  size,
+  placeholder,
+  leftIconComponent,
+  rightIconComponent,
+  ...props
+}) => {
+  const setInputClassName = 'input is-' + size;
+  return (
+    <div className="control has-icons-left has-icons-right">
+      <StyledInput className={setInputClassName} type={type} placeholder={placeholder} {...props} />
+      <Icon align="left">{leftIconComponent || '*'}</Icon>
+      <Icon align="right">{rightIconComponent || '*'}</Icon>
+    </div>
+  );
+};
+
+IconInput.defaultProps = {
+  placeholder: '',
+  size: 'normal',
+  type: 'text',
+};
+
+const StyledInput = styled.input`
+  font-family: 'ImcreSoojin';
+  display: block;
+  width: 100%;
+  border: 2px solid ${Colors.mainFirst};
+  border-radius: 8px;
+  :focus {
+    border-color: ${Colors.mainSecond};
+  }
+  :hover {
+    border-color: ${Colors.subFirst};
+  }
+`;
+
+export default IconInput;


### PR DESCRIPTION
왼쪽, 오른쪽 끝에 아이콘을 넣을 수 있는 인풋 박스

![image](https://user-images.githubusercontent.com/76927397/169868638-41d1a0d3-803a-4551-b007-49980ee07f44.png)


인풋 크기에 따라서 반응형으로 아이콘도 반응형으로 구성했는데

사용해보면서 상황따라서 조절하면 될 것 같습니다