### PR TITLE
회원가입 기능 추가하기

### DIFF
--- a/src/api/config.js
+++ b/src/api/config.js
@@ -2,11 +2,27 @@ import axios from 'axios';
 
 const createInstance = axios.create({
   baseURL: process.env.REACT_APP_MAIN_API || 'http://localhost:8070',
-  headers: {
-    'content-type': 'application/json',
-  },
   timeout: 2000,
 });
+
+createInstance.interceptors.request.use(
+  config => {
+    config.headers['Content-Type'] = 'application/json; charset=utf-8';
+    return config;
+  },
+  error => {
+    return Promise.reject(error.response.data);
+  },
+);
+
+createInstance.interceptors.response.use(
+  response => {
+    return response.data;
+  },
+  error => {
+    return Promise.reject(error.response.data);
+  },
+);
 
 const createAuthInstance = axios.create({
   baseURL: process.env.REACT_APP_MAIN_API || 'http://localhost:8070',
@@ -16,6 +32,26 @@ const createAuthInstance = axios.create({
   },
   timeout: 2000,
 });
+
+createAuthInstance.interceptors.request.use(
+  config => {
+    config.headers['Content-Type'] = 'application/json; charset=utf-8';
+    config.headers['Authorization'] = localStorage.getItem('act');
+    return config;
+  },
+  error => {
+    return Promise.reject(error.response.data);
+  },
+);
+
+createAuthInstance.interceptors.response.use(
+  response => {
+    return response.data;
+  },
+  error => {
+    return Promise.reject(error.response.data);
+  },
+);
 
 export const requestForAll = createInstance;
 export const requestForAuth = createAuthInstance;

--- a/src/api/memberApi.js
+++ b/src/api/memberApi.js
@@ -1,9 +1,15 @@
 import { requestForAll } from './config';
 
+const memberApi = 'api/members';
+
 export const onLogin = async loginForm => {
-  return requestForAll.post('/api/members/login', loginForm).then(result => result);
+  return requestForAll.post(memberApi + '/login', loginForm).then(result => result);
 };
 
 export const onJoin = async joinForm => {
-  return requestForAll.post('/api/members', joinForm).then(result => result);
+  return requestForAll.post(memberApi, joinForm).then(result => result);
+};
+
+export const onCheckNicknameDuplication = async nickname => {
+  return requestForAll.get(memberApi + '/nickname', { params: { nickname } });
 };


### PR DESCRIPTION

**Issue**

- resolves #39


<br>


**구현해야할 사항**

- 닉네임 중복 확인 구현 후 확인 된 상태에서만 회원가입 요청을 할 수 있도록 함.

- 폼 유효성 검사가 된 상태에서 회원가입 버튼 클릭 시 회원가입 api post 요청을 한다.
- 성공 및 실패에 대한 메시지와 함께 alert 를 해준다.
- 이미 직전에 검증 성공한 닉네임에 대해서는 다시 테스트하지 않도록 함

<br>

**향후 고려해야할 사항**

- 이메일 인증 관련 UI 와 api 요청 기능을 추가하고 인증되어야만 회원가입 요청을 할 수 있도록 한다