### PR TITLE
헤더바 개선

### DIFF
--- a/src/components/HamburgerSideBar.js
+++ b/src/components/HamburgerSideBar.js
@@ -6,6 +6,7 @@ import Buttons from './Buttons';
 import { keyframes } from '@emotion/react';
 import { loginState } from '../state/loginState';
 import styled from '@emotion/styled';
+import useClickAway from '../hooks/useClickAway';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 
@@ -17,38 +18,65 @@ const HamburgerSideBar = ({ onCancle, onLogout, visible }) => {
     navigate(path);
   };
 
+  const ref = useClickAway(() => {
+    onCancle && onCancle();
+  });
+
   return (
-    <HamburgerContent disappear={visible}>
-      <Container className="has-text-center p-3">
-        <HamburgerHeader>
-          <HamburgerBackButton size={'large'} onClick={onCancle} />
-        </HamburgerHeader>
-        <Container>
-          <Section>
-            <p className="title">로고</p>
-            <DevideLine />
-            <DevideLine space="micro" color="none" />
-            <p className="subtitle">당신의 LinkyWay를 걸어봐요</p>
-            <p style={{ opacity: 0.7 }}>여기에 뭘 써야 할지 모르겠지만 시작해바요</p>
-            <DevideLine space="medium" color="none" />
-            {!login ? (
-              <>
-                <Buttons onClick={() => handlePageButtonClick('/login')}>로그인</Buttons>
-                <DevideLine space="micro" color="none" />
-                <Buttons onClick={() => handlePageButtonClick('/join')}>회원가입</Buttons>
-              </>
-            ) : (
-              <>
-                <Buttons colortype={'sub'} onClick={onLogout}>
-                  로그아웃
-                </Buttons>
-                <DevideLine space="micro" color="none" />
-              </>
-            )}
-          </Section>
+    <>
+      {visible && <HamburgerBackground />}
+      <HamburgerContent ref={ref} disappear={visible}>
+        <Container className="has-text-center p-3">
+          <HamburgerHeader>
+            <HamburgerBackButton size={'large'} onClick={onCancle} />
+          </HamburgerHeader>
+          <Container>
+            <Section>
+              <p className="title">로고</p>
+              <DevideLine />
+              <DevideLine space="micro" color="none" />
+              <p className="subtitle">당신의 LinkyWay를 걸어봐요</p>
+              <p style={{ opacity: 0.7 }}>여기에 뭘 써야 할지 모르겠지만 시작해바요</p>
+              <DevideLine space="medium" color="none" />
+              {!login ? (
+                <>
+                  <Buttons
+                    onClick={() => {
+                      handlePageButtonClick('/login');
+                      onCancle();
+                    }}
+                  >
+                    로그인
+                  </Buttons>
+                  <DevideLine space="micro" color="none" />
+                  <Buttons
+                    onClick={() => {
+                      handlePageButtonClick('/join');
+                      onCancle();
+                    }}
+                  >
+                    회원가입
+                  </Buttons>
+                </>
+              ) : (
+                <>
+                  <Buttons
+                    colortype={'sub'}
+                    onClick={() => {
+                      onLogout();
+                      onCancle();
+                    }}
+                  >
+                    로그아웃
+                  </Buttons>
+                  <DevideLine space="micro" color="none" />
+                </>
+              )}
+            </Section>
+          </Container>
         </Container>
-      </Container>
-    </HamburgerContent>
+      </HamburgerContent>{' '}
+    </>
   );
 };
 
@@ -70,6 +98,18 @@ const slideRight = keyframes`
   }
 `;
 
+const HamburgerBackground = styled.div`
+  position: fixed;
+  background-color: black;
+  width: 100%;
+  height: 110vh;
+  top: 0;
+  opacity: 0.3;
+  @media ${Media.desktop} {
+    display: none;
+  }
+`;
+
 const HamburgerContent = styled.div`
   z-index: 3;
   position: absolute;
@@ -88,12 +128,13 @@ const HamburgerContent = styled.div`
     width: 60%;
   }
   @media ${Media.mobile} {
-    width: 100%;
+    width: 80%;
   }
   background-color: ${Colors.backgroundForm};
   animation-duration: 0.25s;
   animation-timing-function: ease-out;
   animation-name: ${props => (props.disappear ? slideLeft : slideRight)};
+  min-height: 100vh;
 `;
 
 const HamburgerHeader = styled.div`

--- a/src/components/HamburgerSideBar.js
+++ b/src/components/HamburgerSideBar.js
@@ -1,0 +1,119 @@
+import { BorderRadius, Colors, FontSize, Media, Shadows } from '../styles';
+import { Container, Section } from 'react-bulma-components';
+
+import AnimatedIcon from './icons/AnimatedIcon';
+import Buttons from './Buttons';
+import { keyframes } from '@emotion/react';
+import { loginState } from '../state/loginState';
+import styled from '@emotion/styled';
+import { useNavigate } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+
+const HamburgerSideBar = ({ onCancle, onLogout, visible }) => {
+  const login = useRecoilValue(loginState);
+  const navigate = useNavigate();
+
+  const handlePageButtonClick = path => {
+    navigate(path);
+  };
+
+  return (
+    <HamburgerContent disappear={visible}>
+      <Container className="has-text-center p-3">
+        <HamburgerHeader>
+          <HamburgerBackButton size={'large'} onClick={onCancle} />
+        </HamburgerHeader>
+        <Container>
+          <Section>
+            <p className="title">로고</p>
+            <DevideLine />
+            <DevideLine space="micro" color="none" />
+            <p className="subtitle">당신의 LinkyWay를 걸어봐요</p>
+            <p style={{ opacity: 0.7 }}>여기에 뭘 써야 할지 모르겠지만 시작해바요</p>
+            <DevideLine space="medium" color="none" />
+            {!login ? (
+              <>
+                <Buttons onClick={() => handlePageButtonClick('/login')}>로그인</Buttons>
+                <DevideLine space="micro" color="none" />
+                <Buttons onClick={() => handlePageButtonClick('/join')}>회원가입</Buttons>
+              </>
+            ) : (
+              <>
+                <Buttons colortype={'sub'} onClick={onLogout}>
+                  로그아웃
+                </Buttons>
+                <DevideLine space="micro" color="none" />
+              </>
+            )}
+          </Section>
+        </Container>
+      </Container>
+    </HamburgerContent>
+  );
+};
+
+const slideLeft = keyframes`
+from {
+  transform: translateX(500px);
+}
+to {
+  transform: translateX(0px);
+}
+`;
+
+const slideRight = keyframes`
+  from {
+    transform: translateX(0px);
+  }
+  to {
+    transform: translateX(500px);
+  }
+`;
+
+const HamburgerContent = styled.div`
+  z-index: 3;
+  position: absolute;
+  background-color: ${Colors.backgroundForm};
+  box-shadow: ${Shadows.card};
+  text-align: center;
+  justify-content: center;
+  align-content: center;
+  justify-content: center;
+  top: 0;
+  right: 0;
+  @media ${Media.desktop} {
+    display: none;
+  }
+  @media ${Media.tablet} {
+    width: 60%;
+  }
+  @media ${Media.mobile} {
+    width: 100%;
+  }
+  background-color: ${Colors.backgroundForm};
+  animation-duration: 0.25s;
+  animation-timing-function: ease-out;
+  animation-name: ${props => (props.disappear ? slideLeft : slideRight)};
+`;
+
+const HamburgerHeader = styled.div`
+  text-align: left;
+`;
+
+const HamburgerBackButton = styled(AnimatedIcon.RightArrow)`
+  :hover {
+    border: 2px solid ${Colors.mainFirst};
+    border-radius: ${BorderRadius.button};
+    cursor: pointer;
+  }
+`;
+
+const DevideLine = styled.hr`
+  background-color: ${props => (!props.color ? Colors.mainFirst : props.color)};
+  opacity: 0.6;
+  box-shadow: ${props => (!props.color ? Shadows.button : 'none')};
+  margin-top: ${props => (!props.space ? FontSize.huge : FontSize[props.space])};
+  margin-bottom: ${props => (!props.space ? FontSize.huge : FontSize[props.space])};
+`;
+
+export default HamburgerSideBar;

--- a/src/components/HeaderBar.js
+++ b/src/components/HeaderBar.js
@@ -1,19 +1,15 @@
-import { Container, Navbar, Section } from 'react-bulma-components';
+import { Container, Navbar } from 'react-bulma-components';
 import { Link, useNavigate } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 
-import AnimatedIcon from './icons/AnimatedIcon';
-import { BorderRadius } from '../styles';
-import Buttons from './Buttons';
-import { Colors } from '../styles/colors';
 import { FontSize } from '../styles/font';
+import HamburgerSideBar from './HamburgerSideBar';
 import HeaderSwitcher from './HeaderSwitcher';
 import { Media } from '../styles/media';
 import { Shadows } from '../styles/shadow';
 import Swal from 'sweetalert2';
 import { headerClickState } from '../state/headerState';
-import { keyframes } from '@emotion/react';
 import { loginState } from '../state/loginState';
 import styled from '@emotion/styled';
 
@@ -28,14 +24,6 @@ const HeaderBar = () => {
 
   const handleBurgerClick = () => {
     setVisible(!visible);
-  };
-
-  const handleBurgerCancleClick = () => {
-    setVisible(false);
-  };
-
-  const handlePageButtonClick = path => {
-    navigate(path);
   };
 
   const handleLinkClick = () => {
@@ -118,61 +106,16 @@ const HeaderBar = () => {
           )}
         </HeaderMenu>
       </Container>
-
       {visibleState && (
-        <HamburgerContent disappear={visible}>
-          <Container className="has-text-center p-3">
-            <HamburgerHeader>
-              <HamburgerBackButton size={'large'} onClick={handleBurgerCancleClick} />
-            </HamburgerHeader>
-            <Container>
-              <Section>
-                <p className="title">로고</p>
-                <DevideLine />
-                <DevideLine space="micro" color="none" />
-                <p className="subtitle">당신의 LinkyWay를 걸어봐요</p>
-                <p style={{ opacity: 0.7 }}>여기에 뭘 써야 할지 모르겠지만 시작해바요</p>
-                <DevideLine space="medium" color="none" />
-                {!login ? (
-                  <>
-                    <Buttons onClick={() => handlePageButtonClick('/login')}>로그인</Buttons>
-                    <DevideLine space="micro" color="none" />
-                    <Buttons onClick={() => handlePageButtonClick('/join')}>회원가입</Buttons>
-                  </>
-                ) : (
-                  <>
-                    <Buttons colortype={'sub'} onClick={handleLogoutClick}>
-                      로그아웃
-                    </Buttons>
-                    <DevideLine space="micro" color="none" />
-                  </>
-                )}
-              </Section>
-            </Container>
-          </Container>
-        </HamburgerContent>
+        <HamburgerSideBar
+          onCancle={handleBurgerClick}
+          onLogout={handleLogoutClick}
+          visible={visible}
+        />
       )}
     </StyledNavBar>
   );
 };
-
-const slideLeft = keyframes`
-from {
-  transform: translateX(500px);
-}
-to {
-  transform: translateX(0px);
-}
-`;
-
-const slideRight = keyframes`
-  from {
-    transform: translateX(0px);
-  }
-  to {
-    transform: translateX(500px);
-  }
-`;
 
 const StyledNavBar = styled(Navbar)`
   margin-top: -10px;
@@ -203,52 +146,6 @@ const StyledA = styled.a`
   text-decoration: 1px solid underline;
   text-underline-offset: ${FontSize.normal};
   opacity: 0.7;
-`;
-
-const HamburgerContent = styled.div`
-  z-index: 3;
-  position: absolute;
-  background-color: ${Colors.backgroundForm};
-  box-shadow: ${Shadows.card};
-  text-align: center;
-  justify-content: center;
-  align-content: center;
-  justify-content: center;
-  top: 0;
-  right: 0;
-  @media ${Media.desktop} {
-    display: none;
-  }
-  @media ${Media.tablet} {
-    width: 60%;
-  }
-  @media ${Media.mobile} {
-    width: 100%;
-  }
-  background-color: ${Colors.backgroundForm};
-  animation-duration: 0.25s;
-  animation-timing-function: ease-out;
-  animation-name: ${props => (props.disappear ? slideLeft : slideRight)};
-`;
-
-const HamburgerHeader = styled.div`
-  text-align: left;
-`;
-
-const HamburgerBackButton = styled(AnimatedIcon.RightArrow)`
-  :hover {
-    border: 2px solid ${Colors.mainFirst};
-    border-radius: ${BorderRadius.button};
-    cursor: pointer;
-  }
-`;
-
-const DevideLine = styled.hr`
-  background-color: ${props => (!props.color ? Colors.mainFirst : props.color)};
-  opacity: 0.6;
-  box-shadow: ${props => (!props.color ? Shadows.button : 'none')};
-  margin-top: ${props => (!props.space ? FontSize.huge : FontSize[props.space])};
-  margin-bottom: ${props => (!props.space ? FontSize.huge : FontSize[props.space])};
 `;
 
 const CenterSwitchContainer = styled(StyledLogo)`

--- a/src/components/HeaderBar.js
+++ b/src/components/HeaderBar.js
@@ -1,6 +1,7 @@
 import { Container, Navbar, Section } from 'react-bulma-components';
 import { Link, useNavigate } from 'react-router-dom';
 import { useEffect, useState } from 'react';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 
 import AnimatedIcon from './icons/AnimatedIcon';
 import { BorderRadius } from '../styles';
@@ -11,16 +12,17 @@ import HeaderSwitcher from './HeaderSwitcher';
 import { Media } from '../styles/media';
 import { Shadows } from '../styles/shadow';
 import Swal from 'sweetalert2';
+import { headerClickState } from '../state/headerState';
 import { keyframes } from '@emotion/react';
 import { loginState } from '../state/loginState';
 import styled from '@emotion/styled';
-import { useRecoilState } from 'recoil';
 
 const HeaderBar = () => {
   const [visible, setVisible] = useState(false);
   const [visibleState, setVisibleState] = useState(false);
   const [animationState, setAnimationState] = useState(false);
   const [login, setLogin] = useRecoilState(loginState);
+  const setHeaderSwitch = useSetRecoilState(headerClickState);
 
   const navigate = useNavigate();
 
@@ -36,6 +38,10 @@ const HeaderBar = () => {
     navigate(path);
   };
 
+  const handleLinkClick = () => {
+    setHeaderSwitch(undefined);
+  };
+
   const handleLogoutClick = () => {
     Swal.fire({
       icon: 'success',
@@ -45,6 +51,8 @@ const HeaderBar = () => {
     });
     setLogin(false);
     localStorage.clear();
+    sessionStorage.clear();
+    navigate('/', { replace: true });
   };
 
   useEffect(() => {
@@ -61,7 +69,13 @@ const HeaderBar = () => {
     <StyledNavBar size="large">
       <Container>
         <StyledLogo>
-          <Link className="navbar-item" hoverable={false} style={{ zIndex: '2' }} to={'/'}>
+          <Link
+            className="navbar-item"
+            hoverable={false}
+            style={{ zIndex: '2' }}
+            to={'/'}
+            onClick={handleLinkClick}
+          >
             로고
           </Link>
           <Navbar.Burger
@@ -80,12 +94,14 @@ const HeaderBar = () => {
               <StyledLink
                 className="is-hidden-tablet-only is-hidden-mobile navbar-item"
                 to={'/login'}
+                onClick={handleLinkClick}
               >
                 로그인
               </StyledLink>
               <StyledLink
                 className="is-hidden-tablet-only is-hidden-mobile navbar-item"
                 to={'/join'}
+                onClick={handleLinkClick}
               >
                 회원가입
               </StyledLink>

--- a/src/components/HeaderSwitcher.js
+++ b/src/components/HeaderSwitcher.js
@@ -3,13 +3,14 @@ import { FontSize, Media } from '../styles';
 import { Button } from 'react-bulma-components';
 import CrowdIcon from './icons/CrowdIcon';
 import UserIcon from './icons/UserIcon';
+import { headerClickState } from '../state/headerState';
 import styled from '@emotion/styled';
 import { useNavigate } from 'react-router-dom';
-import { useState } from 'react';
+import { useRecoilState } from 'recoil';
 
 const HeaderSwitcher = ({ colors }) => {
   const navigate = useNavigate();
-  const [clicked, setClicked] = useState(undefined);
+  const [clicked, setClicked] = useRecoilState(headerClickState);
 
   const handleSwitchClick = path => {
     navigate(path);

--- a/src/state/headerState.js
+++ b/src/state/headerState.js
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const headerClickState = atom({
+  key: 'headerClick',
+  default: undefined,
+});


### PR DESCRIPTION
**헤더바**

헤더바 스위치 버튼 강조 상태 관련 수정

- 페이지 이동 시에도 스위치 버튼 강조 효과가 남아있는 부분을 recoil 로 상태처리해  개선함

<br>

**모바일 기기 햄버거 사이드바**

- 내부의 버튼 또는 사이드 바 영역이 아닌 곳을 클릭했을 때 닫혀야 한다. (useClickAway Hook 활용)

- 사이드바가 활성화 되었을 때 영역 이외의 부분들을 어둡게 처리하여 사이드 바가 떠있음을 잘 나타내준다.