### PR TITLE
이메일 인증 UI 및 기능 추가

### DIFF
--- a/src/api/config.js
+++ b/src/api/config.js
@@ -6,7 +6,8 @@ const ACCESS_TOKEN_NAME = TOKEN_INFO.ACCESS_TOKEN_NAME;
 
 const createInstance = axios.create({
   baseURL: process.env.REACT_APP_MAIN_API || 'http://localhost:8070',
-  timeout: 2000,
+  withCredentials: true,
+  timeout: 10000,
 });
 
 createInstance.interceptors.request.use(
@@ -34,7 +35,8 @@ const createAuthInstance = axios.create({
     'content-type': 'application/json',
     Authorization: localStorage.getItem(ACCESS_TOKEN_NAME),
   },
-  timeout: 2000,
+  withCredentials: true,
+  timeout: 10000,
 });
 
 createAuthInstance.interceptors.request.use(

--- a/src/api/emailApi.js
+++ b/src/api/emailApi.js
@@ -1,0 +1,11 @@
+import { requestForAll } from './config';
+
+const emailApi = 'api/email';
+
+export const onRequestEmailCode = email => {
+  return requestForAll.post(emailApi + '/code', { email: email });
+};
+
+export const onVerifyEmailCode = verification => {
+  return requestForAll.post(emailApi + '/confirm', verification);
+};

--- a/src/components/common/CountDownTimer.js
+++ b/src/components/common/CountDownTimer.js
@@ -1,0 +1,30 @@
+import { Colors } from '../../styles';
+import { useCountdown } from '../../hooks/useCountDown';
+
+const CountdownTimer = ({ targetDate }) => {
+  const [hours, minutes, seconds] = useCountdown(targetDate);
+
+  if (hours + minutes + seconds <= 0) {
+    return <p style={{ color: Colors.warningFirst }}>시간 만료됨!</p>;
+  } else {
+    return (
+      <p style={{ color: Colors.warningFirst }} hours={hours} minutes={minutes} seconds={seconds}>
+        남은 시간: {hours !== 0 && getNumberWithZeroPrefix(hours) + ':'}
+        {getNumberWithZeroPrefix(minutes) + ':'}
+        {getNumberWithZeroPrefix(seconds)}
+      </p>
+    );
+  }
+};
+
+const getNumberWithZeroPrefix = time => {
+  if (time > 0 && time < 10) {
+    return '0' + time;
+  }
+  if (time === 0) {
+    return '00';
+  }
+  return time;
+};
+
+export default CountdownTimer;

--- a/src/components/email/EmailValidationForm.js
+++ b/src/components/email/EmailValidationForm.js
@@ -1,0 +1,132 @@
+import * as Yup from 'yup';
+
+import { Colors, FontSize } from '../../styles';
+import { onRequestEmailCode, onVerifyEmailCode } from '../../api/emailApi';
+
+import AnimatedIcon from '../icons/AnimatedIcon';
+import Buttons from '../common/Buttons';
+import { Columns } from 'react-bulma-components';
+import CountdownTimer from '../common/CountDownTimer';
+import { EMAIL_CODE } from '../../constants/business';
+import { FontWeight } from '../../styles/font';
+import IconInput from '../common/IconInput';
+import Swal from 'sweetalert2';
+import { currentJoinFormState } from '../../state/joinState';
+import { onJoin } from '../../api/memberApi';
+import styled from '@emotion/styled';
+import { useFormik } from 'formik';
+import { useRecoilState } from 'recoil';
+import { useState } from 'react';
+
+const EmailValidationForm = () => {
+  const [currentJoinForm, setCurrentJoinForm] = useRecoilState(currentJoinFormState);
+  const [currentTime, setCurrentTime] = useState(new Date().getTime());
+  const initialValues = {
+    email: currentJoinForm.email,
+    code: '',
+  };
+
+  const validationSchema = Yup.object().shape({
+    code: Yup.string()
+      .strict(true)
+      .length(EMAIL_CODE.LENGTH, EMAIL_CODE.MESSAGE)
+      .required(EMAIL_CODE.MESSAGE),
+  });
+
+  const { errors, handleBlur, handleSubmit, handleChange, touched, values } = useFormik({
+    initialValues,
+    validationSchema,
+    onSubmit: async (values, formikHelper) => {
+      formikHelper.setStatus({ success: true });
+      formikHelper.setSubmitting(false);
+      onVerifyEmailCode(values).then(() => {
+        setCurrentJoinForm;
+        onJoin(currentJoinForm)
+          .then(() => {
+            setCurrentJoinForm(undefined);
+            Swal.fire({
+              icon: 'success',
+              text: '회원가입 성공!',
+            }).then(() => {
+              window.location.href = '/';
+            });
+          })
+          .catch(error => {
+            Swal.fire({
+              icon: 'fail',
+              text: error.details || error.message || '회원가입 실패!',
+            });
+          });
+      });
+    },
+  });
+
+  return (
+    <StyledForm onSubmit={handleSubmit}>
+      <div className="control">
+        <h2 className="container has-text-centered title is-2">이메일 인증</h2>
+      </div>
+      <p className="is-size-1">&nbsp;</p>
+      <div className="p-2 mt-2">
+        <p style={{ fontSize: FontSize.normal, fontWeight: FontWeight.bolder }}>
+          메일을 받지 못하셨나요..?
+        </p>
+        <SubDescription className="pt-2">
+          &nbsp;- 정확한 이메일 주소를 입력했나 확인하세요
+        </SubDescription>
+        <SubDescription className="pt-2">
+          &nbsp;- 네트워크 사정에 의한 전송지연일 수 있습니다.
+        </SubDescription>
+        <SubDescription className="pt-2">
+          &nbsp;- 잦은 재요청 시 전송이 제한될 수 있습니다.
+        </SubDescription>
+      </div>
+      <br />
+      <IconInput
+        type="text"
+        name="code"
+        autocomplete="off"
+        onChange={handleChange}
+        onBlur={handleBlur}
+        value={values.code}
+        placeholder="인증코드를 입력해주세요."
+        leftIconComponent={<AnimatedIcon.Password />}
+      />
+      <p
+        className="mt-2"
+        style={{ color: errors.code ? Colors.warningFirst : Colors.successFirst }}
+      >
+        &nbsp;{touched.code && (errors.code || '입력 완료')}
+      </p>
+      <Columns className="is-mobile">
+        <Columns.Column className="is-half">
+          <CountdownTimer targetDate={currentTime + EMAIL_CODE.EXPIRATION_MILLS} />
+        </Columns.Column>
+        <Columns.Column className="is-half">
+          <a
+            onClick={() => {
+              setCurrentTime(new Date().getTime());
+              onRequestEmailCode(values.email);
+            }}
+          >
+            재전송
+          </a>
+        </Columns.Column>
+      </Columns>
+      <div className="control">
+        <Buttons type={'submit'}>인증하기</Buttons>
+      </div>
+    </StyledForm>
+  );
+};
+
+const StyledForm = styled.form`
+  width: 100%;
+`;
+
+const SubDescription = styled.p`
+  font-size: ${FontSize.small};
+  color: darkGrey;
+`;
+
+export default EmailValidationForm;

--- a/src/components/member/JoinForm.js
+++ b/src/components/member/JoinForm.js
@@ -1,0 +1,238 @@
+import * as Yup from 'yup';
+
+import { Colors, FontSize, Shadows } from '../../styles';
+import { useEffect, useState } from 'react';
+
+import AnimatedIcon from '../icons/AnimatedIcon';
+import Buttons from '../common/Buttons';
+import { Columns } from 'react-bulma-components';
+import IconInput from '../common/IconInput';
+import Swal from 'sweetalert2';
+import { currentJoinFormState } from '../../state/joinState';
+import { onCheckNicknameDuplication } from '../../api/memberApi';
+import { onRequestEmailCode } from '../../api/emailApi';
+import styled from '@emotion/styled';
+import { useFormik } from 'formik';
+import { useSetRecoilState } from 'recoil';
+
+const JoinForm = ({ setFormSubmitted }) => {
+  const [validNickname, setValidNickname] = useState(false);
+  const [validNicknameHistory, setValidNicknameHistory] = useState(undefined);
+  const setCurrentJoinForm = useSetRecoilState(currentJoinFormState);
+  const [currentEmail, setCurrentEmail] = useState();
+
+  const initialValues = {
+    email: '',
+    nickname: '',
+    password: '',
+    checkPassword: '',
+  };
+
+  const validationSchema = Yup.object().shape({
+    email: Yup.string()
+      .strict(true)
+      .email('이메일 형식으로 작성해주세요.')
+      .required('이메일을 입력해주세요.'),
+    nickname: Yup.string()
+      .strict(true)
+      .required('닉네임을 입력해주세요')
+      .matches(/^[a-zA-Z0-9가-힣_]{2,10}$/, '2~10 글자의 문자를 입력해주세요'),
+    password: Yup.string()
+      .required('비밀번호를 입력하세요')
+      .matches(
+        /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{4,16}$/,
+        '비밀번호는 4~16자의 대소영문자,숫자,특수문자를 포함해야 합니다',
+      ),
+    checkPassword: Yup.string()
+      .oneOf([Yup.ref('password'), null], '비밀번호가 일치하지 않습니다.')
+      .required('확인 비밀번호를 입력해주세요.'),
+  });
+
+  const { errors, handleBlur, handleSubmit, handleChange, touched, values } = useFormik({
+    initialValues,
+    validationSchema,
+    onSubmit: async (values, formikHelper) => {
+      if (!validNickname) {
+        Swal.fire({
+          icon: 'error',
+          title: '닉네임 중복 확인을 해주세요.',
+        });
+        return;
+      }
+      try {
+        onRequestEmailCode(currentEmail);
+        setFormSubmitted(true);
+        setCurrentJoinForm(values);
+        formikHelper.resetForm();
+        formikHelper.setStatus({ success: true });
+        formikHelper.setSubmitting(false);
+      } catch (error) {
+        Swal.fire({
+          icon: 'error',
+          text: '인증코드 전송 실패',
+        });
+      }
+    },
+  });
+
+  const handleNicknameInputChange = event => {
+    validNicknameHistory && event.target.value === validNicknameHistory
+      ? setValidNickname(true)
+      : setValidNickname(false);
+    handleChange(event);
+  };
+
+  const resolveRightIconComponent = val => {
+    return (
+      touched[val] &&
+      (!errors[val] ? (
+        <AnimatedIcon.CheckMark size={'large'} />
+      ) : (
+        <AnimatedIcon.WarningAlert size={'large'} />
+      ))
+    );
+  };
+
+  const handleCheckDuplicatedNameButton = async nickname => {
+    if (errors.nickname) {
+      return;
+    }
+
+    const result = await onCheckNicknameDuplication(nickname);
+
+    if (result.data && validNicknameHistory !== nickname) {
+      const usable = result.data.usable;
+      if (usable) {
+        setValidNickname(true);
+        setValidNicknameHistory(nickname);
+      }
+      Swal.fire({
+        icon: usable ? 'success' : 'warning',
+        text: usable ? `'${nickname}' 사용 가능!` : '이미 존재하는 닉네임 입니다.',
+      });
+    }
+  };
+
+  useEffect(() => {
+    setCurrentEmail(values.email);
+  }, [values.email]);
+
+  return (
+    <StyledForm onSubmit={handleSubmit}>
+      <p className="container has-text-centered title is-2">회원가입</p>
+      <DevideLine space="small" color="none" />
+      <label className="label">이메일</label>
+      <IconInput
+        name="email"
+        type="text"
+        onChange={handleChange}
+        onBlur={handleBlur}
+        value={values.email}
+        autocomplete="off"
+        placeholder="이메일을 입력하세요"
+        required
+        leftIconComponent={<AnimatedIcon.Email />}
+        rightIconComponent={resolveRightIconComponent('email')}
+      />
+      <p
+        className="m-2"
+        style={{ color: errors.email ? Colors.warningFirst : Colors.successFirst }}
+      >
+        &nbsp;{touched.email && (errors.email || '이메일 입력이 확인되었어요')}
+      </p>
+      <Columns>
+        <DevideLine space="micro" color="none" />
+        <Columns.Column className="is-12 pb-0" style={{ width: '100%' }}>
+          <label className="label">닉네임</label>
+        </Columns.Column>
+        <Columns.Column className="is-8">
+          <IconInput
+            type="text"
+            name="nickname"
+            autocomplete="off"
+            required
+            placeholder="닉네임을 입력하세요"
+            onChange={handleNicknameInputChange}
+            onBlur={handleBlur}
+            value={values.nickname}
+            leftIconComponent={<AnimatedIcon.CommonInput />}
+            rightIconComponent={resolveRightIconComponent('nickname')}
+          />
+        </Columns.Column>
+        <Columns.Column>
+          <Buttons type="button" onClick={() => handleCheckDuplicatedNameButton(values.nickname)}>
+            중복확인
+          </Buttons>
+        </Columns.Column>
+        <p style={{ color: errors.nickname ? Colors.warningFirst : Colors.successFirst }}>
+          &nbsp;&nbsp;&nbsp;&nbsp;
+          {touched.nickname &&
+            (errors.nickname ||
+              (validNickname ? '닉네임 검증 완료!' : '닉네임 입력이 확인되었어요'))}
+        </p>
+      </Columns>
+      <DevideLine space="micro" color="none" />
+      <label className="label">비밀번호</label>
+      <IconInput
+        id="password"
+        name="password"
+        type="password"
+        onChange={handleChange}
+        onBlur={handleBlur}
+        value={values.password}
+        autocomplete="off"
+        placeholder="비밀번호를 입력하세요"
+        required
+        leftIconComponent={<AnimatedIcon.Password />}
+        rightIconComponent={resolveRightIconComponent('password')}
+      />
+      <p
+        className="m-2"
+        style={{ color: errors.password ? Colors.warningFirst : Colors.successFirst }}
+      >
+        &nbsp;{touched.password && (errors.password || '비밀번호 입력이 확인되었어요')}
+      </p>
+      <DevideLine space="micro" color="none" />
+      <label className="label">비밀번호 확인</label>
+      <IconInput
+        name="checkPassword"
+        type="password"
+        onChange={handleChange}
+        onBlur={handleBlur}
+        value={values.checkPassword}
+        autocomplete="off"
+        placeholder="비밀번호를 확인해줏세요"
+        required
+        leftIconComponent={<AnimatedIcon.Password />}
+        rightIconComponent={resolveRightIconComponent('checkPassword')}
+      />
+      <p
+        className="m-2"
+        style={{
+          color: errors.checkPassword ? Colors.warningFirst : Colors.successFirst,
+        }}
+      >
+        &nbsp;
+        {touched.checkPassword && (errors.checkPassword || '비밀번호 입력이 확인되었어요')}
+      </p>
+
+      <DevideLine color="none" />
+      <Buttons type={'submit'}>회원가입</Buttons>
+      <DevideLine space="medium" color="none" />
+    </StyledForm>
+  );
+};
+
+const DevideLine = styled.hr`
+  background-color: ${props => (!props.color ? Colors.mainFirst : props.color)};
+  opacity: 0.6;
+  box-shadow: ${props => (!props.color ? Shadows.button : 'none')};
+  margin-top: ${props => (!props.space ? Shadows.huge : FontSize[props.space])};
+  margin-bottom: ${props => (!props.space ? FontSize.huge : FontSize[props.space])};
+`;
+
+const StyledForm = styled.form`
+  width: 100%;
+`;
+
+export default JoinForm;

--- a/src/constants/business.js
+++ b/src/constants/business.js
@@ -6,3 +6,9 @@ export const FOLDER = {
     REQUIRE: '폴더 이름을 입력하세요',
   },
 };
+
+export const EMAIL_CODE = {
+  LENGTH: 8,
+  MESSAGE: '올바른 인증 코드를 입력해주세요',
+  EXPIRATION_MILLS: 1000 * 60 * 5,
+};

--- a/src/hooks/useCountDown.js
+++ b/src/hooks/useCountDown.js
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+const useCountdown = targetDate => {
+  const countDownDate = new Date(targetDate).getTime();
+
+  const [countDown, setCountDown] = useState(countDownDate - new Date().getTime());
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCountDown(countDownDate - new Date().getTime());
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [countDownDate]);
+
+  return getReturnValues(countDown);
+};
+
+const getReturnValues = countDown => {
+  const hours = Math.floor((countDown % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+  const minutes = Math.floor((countDown % (1000 * 60 * 60)) / (1000 * 60));
+  const seconds = Math.floor((countDown % (1000 * 60)) / 1000);
+  return [hours, minutes, seconds];
+};
+
+export { useCountdown };

--- a/src/pages/JoinPage.js
+++ b/src/pages/JoinPage.js
@@ -1,275 +1,36 @@
-import * as Yup from 'yup';
-
-import { Colors, FontSize, Shadows } from '../styles';
 import { Columns, Container, Hero } from 'react-bulma-components';
-import { onCheckNicknameDuplication, onJoin } from '../api/memberApi';
 
-import AnimatedIcon from '../components/icons/AnimatedIcon';
-import Buttons from '../components/common/Buttons';
-import IconInput from '../components/common/IconInput';
-import Swal from 'sweetalert2';
+import EmailValidationForm from '../components/email/EmailValidationForm';
+import JoinForm from '../components/member/JoinForm';
 import styled from '@emotion/styled';
-import { useFormik } from 'formik';
-import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 
 const JoinPage = () => {
-  const navigate = useNavigate();
-  const [validNickname, setValidNickname] = useState(false);
-  const [validNicknameHistory, setValidNicknameHistory] = useState(undefined);
-  const initialValues = {
-    email: '',
-    nickname: '',
-    password: '',
-    checkPassword: '',
-  };
-
-  const validationSchema = Yup.object().shape({
-    email: Yup.string()
-      .strict(true)
-      .email('이메일 형식으로 작성해주세요.')
-      .required('이메일을 입력해주세요.'),
-    nickname: Yup.string()
-      .strict(true)
-      .required('닉네임을 입력해주세요')
-      .matches(/^[a-zA-Z0-9가-힣_]{2,10}$/, '2~10 글자의 문자를 입력해주세요'),
-    password: Yup.string()
-      .required('비밀번호를 입력하세요')
-      .matches(
-        /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{4,16}$/,
-        '비밀번호는 4~16자의 대소영문자,숫자,특수문자를 포함해야 합니다',
-      ),
-    checkPassword: Yup.string()
-      .oneOf([Yup.ref('password'), null], '비밀번호가 일치하지 않습니다.')
-      .required('확인 비밀번호를 입력해주세요.'),
-  });
-
-  const { errors, handleBlur, handleSubmit, handleChange, touched, values } = useFormik({
-    initialValues,
-    validationSchema,
-    onSubmit: async (values, formikHelper) => {
-      if (!validNickname) {
-        Swal.fire({
-          icon: 'error',
-          title: '닉네임 중복 확인을 해주세요.',
-        });
-        return;
-      }
-      try {
-        formikHelper.resetForm();
-        formikHelper.setStatus({ success: true });
-        formikHelper.setSubmitting(false);
-        const result = await onJoin(values);
-
-        if (result.code <= 201) {
-          Swal.fire({
-            icon: 'success',
-            text: '회원가입 성공!!',
-          }).then(() => {
-            navigate('/');
-          });
-        }
-      } catch (error) {
-        Swal.fire({
-          icon: 'error',
-          text: `회원가입 실패: ${error.details}`,
-        });
-      }
-    },
-  });
-
-  const handleEmailAuthenticationButtonClick = () => {
-    if (errors.email) {
-      Swal.fire({
-        icon: 'warning',
-        text: '이메일 입력을 확인하세요',
-      });
-    } else {
-      Swal.fire({
-        icon: 'success',
-        text: '이메일 인증을 준비중입니다.',
-      });
-    }
-  };
-
-  const handleCheckDuplicatedNameButton = async nickname => {
-    if (errors.nickname) {
-      return;
-    }
-
-    const result = await onCheckNicknameDuplication(nickname);
-
-    if (result.data && validNicknameHistory !== nickname) {
-      const usable = result.data.usable;
-      if (usable) {
-        setValidNickname(true);
-        setValidNicknameHistory(nickname);
-      }
-      Swal.fire({
-        icon: usable ? 'success' : 'warning',
-        text: usable ? `'${nickname}' 사용 가능!` : '이미 존재하는 닉네임 입니다.',
-      });
-    }
-  };
-
-  const handleNicknameInputChange = event => {
-    validNicknameHistory && event.target.value === validNicknameHistory
-      ? setValidNickname(true)
-      : setValidNickname(false);
-    handleChange(event);
-  };
-
-  const resolveRightIconComponent = val => {
-    return (
-      touched[val] &&
-      (!errors[val] ? (
-        <AnimatedIcon.CheckMark size={'large'} />
-      ) : (
-        <AnimatedIcon.WarningAlert size={'large'} />
-      ))
-    );
-  };
+  const [formSubmitted, setFormSubmitted] = useState(false);
 
   return (
-    <>
-      <Hero size={'fullheight'}>
-        <StyledHeroBody>
-          <Container>
-            <Columns.Column
-              className="is-half-desktop is-offset-3-desktop is-8-tablet is-offset-2-tablet is-fullwidth-mobile"
-              style={{
-                display: 'flex',
-                justifyContent: 'center',
-              }}
-            >
-              <StyledForm onSubmit={handleSubmit}>
-                <p className="container has-text-centered title is-2">회원가입</p>
-                <DevideLine space="small" color="none" />
-                <label className="label">이메일</label>
-                <IconInput
-                  name="email"
-                  type="text"
-                  onChange={handleChange}
-                  onBlur={handleBlur}
-                  value={values.email}
-                  autocomplete="off"
-                  placeholder="이메일을 입력하세요"
-                  required
-                  leftIconComponent={<AnimatedIcon.Email />}
-                  rightIconComponent={resolveRightIconComponent('email')}
-                />
-                <p
-                  className="m-2"
-                  style={{ color: errors.email ? Colors.warningFirst : Colors.successFirst }}
-                >
-                  &nbsp;{touched.email && (errors.email || '이메일 입력이 확인되었어요')}
-                </p>
-                <Buttons type="button" onClick={handleEmailAuthenticationButtonClick}>
-                  이메일 인증번호 전송
-                </Buttons>
-                <DevideLine space="medium" color="none" />
-                <Columns>
-                  <Columns.Column className="is-12 pb-0" style={{ width: '100%' }}>
-                    <label className="label">닉네임</label>
-                  </Columns.Column>
-                  <Columns.Column className="is-8">
-                    <IconInput
-                      type="text"
-                      name="nickname"
-                      autocomplete="off"
-                      required
-                      placeholder="닉네임을 입력하세요"
-                      onChange={handleNicknameInputChange}
-                      onBlur={handleBlur}
-                      value={values.nickname}
-                      leftIconComponent={<AnimatedIcon.CommonInput />}
-                      rightIconComponent={resolveRightIconComponent('nickname')}
-                    />
-                  </Columns.Column>
-                  <Columns.Column>
-                    <Buttons
-                      type="button"
-                      onClick={() => handleCheckDuplicatedNameButton(values.nickname)}
-                    >
-                      중복확인
-                    </Buttons>
-                  </Columns.Column>
-                  <p style={{ color: errors.nickname ? Colors.warningFirst : Colors.successFirst }}>
-                    &nbsp;&nbsp;&nbsp;&nbsp;
-                    {touched.nickname &&
-                      (errors.nickname ||
-                        (validNickname ? '닉네임 검증 완료!' : '닉네임 입력이 확인되었어요'))}
-                  </p>
-                </Columns>
-                <DevideLine space="micro" color="none" />
-                <label className="label">비밀번호</label>
-                <IconInput
-                  id="password"
-                  name="password"
-                  type="password"
-                  onChange={handleChange}
-                  onBlur={handleBlur}
-                  value={values.password}
-                  autocomplete="off"
-                  placeholder="비밀번호를 입력하세요"
-                  required
-                  leftIconComponent={<AnimatedIcon.Password />}
-                  rightIconComponent={resolveRightIconComponent('password')}
-                />
-                <p
-                  className="m-2"
-                  style={{ color: errors.password ? Colors.warningFirst : Colors.successFirst }}
-                >
-                  &nbsp;{touched.password && (errors.password || '비밀번호 입력이 확인되었어요')}
-                </p>
-                <label className="label">비밀번호 확인</label>
-                <IconInput
-                  name="checkPassword"
-                  type="password"
-                  onChange={handleChange}
-                  onBlur={handleBlur}
-                  value={values.checkPassword}
-                  autocomplete="off"
-                  placeholder="비밀번호를 확인해줏세요"
-                  required
-                  leftIconComponent={<AnimatedIcon.Password />}
-                  rightIconComponent={resolveRightIconComponent('checkPassword')}
-                />
-                <p
-                  className="m-2"
-                  style={{
-                    color: errors.checkPassword ? Colors.warningFirst : Colors.successFirst,
-                  }}
-                >
-                  &nbsp;
-                  {touched.checkPassword &&
-                    (errors.checkPassword || '비밀번호 입력이 확인되었어요')}
-                </p>
-
-                <DevideLine color="none" />
-                <Buttons type={'submit'}>회원가입</Buttons>
-                <DevideLine space="medium" color="none" />
-              </StyledForm>
-            </Columns.Column>
-          </Container>
-        </StyledHeroBody>
-      </Hero>
-    </>
+    <Hero size={'fullheight'}>
+      <StyledHeroBody>
+        <Container>
+          <Columns.Column
+            className="is-half-desktop is-offset-3-desktop is-8-tablet is-offset-2-tablet is-fullwidth-mobile"
+            style={{
+              display: 'flex',
+              justifyContent: 'center',
+            }}
+          >
+            {formSubmitted ? (
+              <EmailValidationForm />
+            ) : (
+              <JoinForm setFormSubmitted={setFormSubmitted} />
+            )}
+          </Columns.Column>
+        </Container>
+      </StyledHeroBody>
+    </Hero>
   );
 };
 
 const StyledHeroBody = styled(Hero.Body)``;
-
-const StyledForm = styled.form`
-  width: 100%;
-`;
-
-const DevideLine = styled.hr`
-  background-color: ${props => (!props.color ? Colors.mainFirst : props.color)};
-  opacity: 0.6;
-  box-shadow: ${props => (!props.color ? Shadows.button : 'none')};
-  margin-top: ${props => (!props.space ? Shadows.huge : FontSize[props.space])};
-  margin-bottom: ${props => (!props.space ? FontSize.huge : FontSize[props.space])};
-`;
 
 export default JoinPage;

--- a/src/state/joinState.js
+++ b/src/state/joinState.js
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const currentJoinFormState = atom({
+  key: 'currentJoinForm',
+  default: undefined,
+});


### PR DESCRIPTION


**추가 및 개선사항**

- 타이머 hook 과 컴포넌트 추가하여 이메일 인증 시 사용

- 회원가입 페이지에서 폼을 컴포넌트로 분리하고 회원가입 폼 등록자체(onSubmit)를 이메일 인증 코드 전송 api로 대체

- 폼 등록 시 나오는 UI에서 인증코드를 입력해야 실제로 회원가입이 됨


<br>

**TODO**

- 비밀번호 찾기 UI와 기능 구현 시에도 이메일 인증이 필요하기 때문에 두 상황에 맞게 이메일 인증 컴포넌트를 사용할 수 있도록 잘 개선해야한다.  