### PR TITLE
폴더 드래그 경로 수정 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "formik": "^2.2.9",
         "jwt-decode": "^3.1.2",
         "react": "^18.1.0",
+        "react-beautiful-dnd": "^13.1.0",
         "react-bulma-components": "^4.1.0",
         "react-dom": "^18.1.0",
         "react-intersection-observer": "^9.1.0",
@@ -3937,6 +3938,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -4051,6 +4061,17 @@
       "integrity": "sha512-FgTtbqPOCI3dzZPZoC2T/sx3L34qxy99ITWn4eoSA95qPyXDMH0ALoAqUp49ITniiJFsXUVBtalh/KffMpg21Q==",
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-redux": {
+      "version": "7.1.24",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.24.tgz",
+      "integrity": "sha512-7FkurKcS1k0FHZEtdbbgN8Oc6b+stGSfZYjQGicofJ0j4U0qIn/jaSvnP2pLwZKiai3/17xqqxkkrxTgN8UNbQ==",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
       }
     },
     "node_modules/@types/resolve": {
@@ -6059,6 +6080,14 @@
       },
       "peerDependencies": {
         "postcss": "^8.4"
+      }
+    },
+    "node_modules/css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "dependencies": {
+        "tiny-invariant": "^1.0.6"
       }
     },
     "node_modules/css-declaration-sorter": {
@@ -11832,6 +11861,11 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
+    },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -13973,6 +14007,11 @@
         "performance-now": "^2.1.0"
       }
     },
+    "node_modules/raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ=="
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -14047,6 +14086,32 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/react-beautiful-dnd": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.1.0.tgz",
+      "integrity": "sha512-aGvblPZTJowOWUNiwd6tNfEpgkX5OxmpqxHKNW/4VmvZTNTbeiq7bA3bn5T+QSF2uibXB0D1DmJsb1aC/+3cUA==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2",
+        "css-box-model": "^1.2.0",
+        "memoize-one": "^5.1.1",
+        "raf-schd": "^4.0.2",
+        "react-redux": "^7.2.0",
+        "redux": "^4.0.4",
+        "use-memo-one": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.5 || ^17.0.0",
+        "react-dom": "^16.8.5 || ^17.0.0"
+      }
+    },
+    "node_modules/react-beautiful-dnd/node_modules/use-memo-one": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.2.tgz",
+      "integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/react-bulma-components": {
@@ -14230,6 +14295,30 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "7.2.8",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.8.tgz",
+      "integrity": "sha512-6+uDjhs3PSIclqoCk0kd6iX74gzrGc3W5zcAjbrFgEdIjRSQObdIwfx80unTkVUYvbQ95Y8Av3OvFHq1w5EOUw==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "@types/react-redux": "^7.1.20",
+        "hoist-non-react-statics": "^3.3.2",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17 || ^18"
       },
       "peerDependenciesMeta": {
         "react-dom": {
@@ -14438,6 +14527,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/regenerate": {
@@ -15865,6 +15962,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
+      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
     },
     "node_modules/tiny-warning": {
       "version": "1.0.3",
@@ -19864,6 +19966,15 @@
         "@types/node": "*"
       }
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -19978,6 +20089,17 @@
       "integrity": "sha512-FgTtbqPOCI3dzZPZoC2T/sx3L34qxy99ITWn4eoSA95qPyXDMH0ALoAqUp49ITniiJFsXUVBtalh/KffMpg21Q==",
       "requires": {
         "@types/react": "*"
+      }
+    },
+    "@types/react-redux": {
+      "version": "7.1.24",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.24.tgz",
+      "integrity": "sha512-7FkurKcS1k0FHZEtdbbgN8Oc6b+stGSfZYjQGicofJ0j4U0qIn/jaSvnP2pLwZKiai3/17xqqxkkrxTgN8UNbQ==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
       }
     },
     "@types/resolve": {
@@ -21505,6 +21627,14 @@
       "integrity": "sha512-VS90XWtsHGqoM0t4KpH053c4ehxZ2E6HtGI7x68YFV0pTo/QmkV/YFA+NnlvK8guxZVNWGQhVNJGC39Q8XF4OQ==",
       "requires": {
         "postcss-selector-parser": "^6.0.9"
+      }
+    },
+    "css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "requires": {
+        "tiny-invariant": "^1.0.6"
       }
     },
     "css-declaration-sorter": {
@@ -25678,6 +25808,11 @@
         "fs-monkey": "1.0.3"
       }
     },
+    "memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
+    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -27067,6 +27202,11 @@
         "performance-now": "^2.1.0"
       }
     },
+    "raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ=="
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -27125,6 +27265,28 @@
         "raf": "^3.4.1",
         "regenerator-runtime": "^0.13.9",
         "whatwg-fetch": "^3.6.2"
+      }
+    },
+    "react-beautiful-dnd": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.1.0.tgz",
+      "integrity": "sha512-aGvblPZTJowOWUNiwd6tNfEpgkX5OxmpqxHKNW/4VmvZTNTbeiq7bA3bn5T+QSF2uibXB0D1DmJsb1aC/+3cUA==",
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "css-box-model": "^1.2.0",
+        "memoize-one": "^5.1.1",
+        "raf-schd": "^4.0.2",
+        "react-redux": "^7.2.0",
+        "redux": "^4.0.4",
+        "use-memo-one": "^1.1.1"
+      },
+      "dependencies": {
+        "use-memo-one": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.2.tgz",
+          "integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ==",
+          "requires": {}
+        }
       }
     },
     "react-bulma-components": {
@@ -27259,6 +27421,19 @@
         "@babel/runtime": "^7.5.5",
         "broadcast-channel": "^3.4.1",
         "match-sorter": "^6.0.2"
+      }
+    },
+    "react-redux": {
+      "version": "7.2.8",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.8.tgz",
+      "integrity": "sha512-6+uDjhs3PSIclqoCk0kd6iX74gzrGc3W5zcAjbrFgEdIjRSQObdIwfx80unTkVUYvbQ95Y8Av3OvFHq1w5EOUw==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "@types/react-redux": "^7.1.20",
+        "hoist-non-react-statics": "^3.3.2",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2"
       }
     },
     "react-refresh": {
@@ -27403,6 +27578,14 @@
       "requires": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
+      }
+    },
+    "redux": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+      "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
+      "requires": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "regenerate": {
@@ -28464,6 +28647,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
+    },
+    "tiny-invariant": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
+      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
     },
     "tiny-warning": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "formik": "^2.2.9",
     "jwt-decode": "^3.1.2",
     "react": "^18.1.0",
+    "react-beautiful-dnd": "^13.1.0",
     "react-bulma-components": "^4.1.0",
     "react-dom": "^18.1.0",
     "react-intersection-observer": "^9.1.0",

--- a/src/api/folderApi.js
+++ b/src/api/folderApi.js
@@ -33,3 +33,7 @@ export const onUpdateFolderName = (folderId, folderName) => {
 export const onAddFolder = ({ name, parentFolderId }) => {
   return requestForAuth.post(folderApi, { name, parentFolderId });
 };
+
+export const onChangeFolderPath = (currentId, targetId) => {
+  return requestForAuth.put(folderApi + `/${currentId}/path`, { targetFolderId: targetId });
+};

--- a/src/components/card/CardAddForm.js
+++ b/src/components/card/CardAddForm.js
@@ -274,7 +274,14 @@ const CardAddForm = ({ onClose, active, method = 'CREATE', currentCardId }) => {
                         value={f.folderId}
                         selected={currentCard && currentCard.folderId === f.filderId}
                       >
-                        {f.level >= 3 ? '- ' + f.name : f.name}
+                        {[...Array(f.level)].map((v, i) => {
+                          console.log(f.level);
+                          if (i === 0) {
+                            return;
+                          }
+                          return <span key={i}>- </span>;
+                        })}
+                        {f.name}
                       </option>
                     );
                   })}

--- a/src/components/folder/FolderAddForm.js
+++ b/src/components/folder/FolderAddForm.js
@@ -78,10 +78,13 @@ const FolderAddForm = ({ onClose }) => {
                 <option value="">없음</option>
                 {folders &&
                   folders
-                    .filter(folder => folder.level === FOLDER.DEPTH_LIMIT - 1)
+                    .filter(folder => folder.level <= FOLDER.DEPTH_LIMIT - 1 && folder.level !== 0)
                     .map(f => {
                       return (
                         <option key={f.folderId} value={f.folderId}>
+                          {[...Array(f.level - 1)].map((v, i) => {
+                            return <span key={i}>- </span>;
+                          })}
                           {f.name || '이름없음'}
                         </option>
                       );

--- a/src/components/folder/FolderAddForm.js
+++ b/src/components/folder/FolderAddForm.js
@@ -57,11 +57,11 @@ const FolderAddForm = ({ onClose }) => {
     validationSchema,
     onSubmit: async (values, formikHelper) => {
       handleAddFolder(values);
-      formikHelper.resetForm();
       formikHelper.setStatus({ success: true });
       formikHelper.setSubmitting(false);
     },
   });
+
   return (
     <form onSubmit={handleSubmit}>
       <Section>

--- a/src/components/folder/FolderBox.js
+++ b/src/components/folder/FolderBox.js
@@ -106,7 +106,9 @@ const FolderBox = ({ children, folderId, highlight, idx, parent, level }) => {
         onDeleteFolder(folderId).then(() => {
           queryClient.setQueriesData(
             FOLDER_QUERY_KEY,
-            folders.filter(folder => folder.folderId !== folderId),
+            folders.filter(
+              folder => !(folder.folderId === folderId || folder.parentId === folderId),
+            ),
           );
         });
       }

--- a/src/components/folder/FolderBox.js
+++ b/src/components/folder/FolderBox.js
@@ -126,13 +126,21 @@ const FolderBox = ({ children, folderId, highlight, idx, parent, level }) => {
   return (
     <Wrapper ref={hoverRef}>
       &nbsp;
-      {parent && (
-        <Icon className="is-large">
-          <span>
-            <NormalIcon.FolderArrow />
-          </span>
-        </Icon>
-      )}
+      {parent &&
+        [...Array(level)].map((value, index) => {
+          const opacity = index === level - 1 ? 1 : 0;
+          if (index === 0) {
+            return;
+          }
+          return (
+            <Icon key={index} className="is-medium">
+              <span>
+                &nbsp;&nbsp;
+                <NormalIcon.FolderArrow opacity={opacity} />
+              </span>
+            </Icon>
+          );
+        })}
       <Icon className="is-large">
         <AnimatedIcon.Folder size={30} />
       </Icon>

--- a/src/components/icons/normal/FolderArrow.js
+++ b/src/components/icons/normal/FolderArrow.js
@@ -1,7 +1,7 @@
 import { IconSize } from '../../../styles';
 import styled from '@emotion/styled';
 
-const FolderArrow = ({ size }) => {
+const FolderArrow = ({ size, opacity = 1 }) => {
   return (
     <StyledSvg viewBox="-80 0 300 250" xmlns="http://www.w3.org/2000/svg" size={size}>
       <rect fill="none" />
@@ -12,6 +12,7 @@ const FolderArrow = ({ size }) => {
         strokeLinecap="round"
         strokeLinejoin="round"
         strokeWidth="17"
+        opacity={opacity}
       />
       <polyline
         fill="none"
@@ -20,6 +21,7 @@ const FolderArrow = ({ size }) => {
         strokeLinecap="round"
         strokeLinejoin="round"
         strokeWidth="17"
+        opacity={opacity}
       />
     </StyledSvg>
   );
@@ -32,6 +34,8 @@ FolderArrow.defaultProps = {
 const StyledSvg = styled.svg`
   width: ${({ size }) => size + 'px'};
   height: auto;
+  margin-top: 2px;
+  margin-left: 2px;
 `;
 
 export default FolderArrow;

--- a/src/constants/business.js
+++ b/src/constants/business.js
@@ -1,5 +1,5 @@
 export const FOLDER = {
-  DEPTH_LIMIT: 2,
+  DEPTH_LIMIT: 3,
   NAME_VALIDATION: {
     REGEX: /^[가-힣a-zA-Z\d_]{1,10}$/,
     MESSAGE: '한글,영어,숫자,언더바(_) 10글자 이하로 입력하세요',


### PR DESCRIPTION
resolves #104

<br>

**구현한 것**

- react beautiful dnd 라이브러리를 활용해 폴더 구조를 드래그 할 수 있도록 함.

**적용한 경로 변경 규칙**

> 루트 폴더(카드 미분류) 는 논외

> 최하위 폴더일 경우 부모폴더와 다른 최하위 폴더를 제외하고 어디로든 경로변경이 가능하다.

> 최하위 폴더가 아닌 폴더는 같은 계층의 폴더 내부의 자식으로 들어갈 수 있다.

<br>

**안되는 것**

> api 상 문제로 하위폴더일 때 최상단으로 이동이 불가능하다.

>api 상  문제로 같은계층의 폴더 내부의 자식으로 이동이 불가능하다

<br>

**추가할법한 것**

> 동일한 계층의 폴더로 이동 요청 시 해당 폴더에 속한 카드들을 병합한다.

> 부모 폴더로 이동 요청 시 부모 폴더에 해당 폴더에 속한 카드들을 병합한다.

<br>

**특이사항**

- 문제 모두 해결 후 리뷰 후 머지