### PR TITLE
form 중심 페이지에서 타이틀 분리

### DIFF
--- a/src/components/common/PageTitle.js
+++ b/src/components/common/PageTitle.js
@@ -1,0 +1,24 @@
+import { Container, Hero } from 'react-bulma-components';
+
+import { FontWeight } from '../../styles/font';
+import styled from '@emotion/styled';
+
+const PageTitle = ({ children }) => {
+  return (
+    <Hero size={'medium'}>
+      <Hero.Body className="mb-0 pb-2">
+        <Container className="has-text-centered">
+          <TitleText className="is-size-2-desktop is-size-3-tablet is-size-4-mobile">
+            {children}
+          </TitleText>
+        </Container>
+      </Hero.Body>
+    </Hero>
+  );
+};
+
+const TitleText = styled.p`
+  font-weight: ${FontWeight.bold};
+`;
+
+export default PageTitle;

--- a/src/components/email/EmailValidationForm.js
+++ b/src/components/email/EmailValidationForm.js
@@ -63,10 +63,6 @@ const EmailValidationForm = () => {
 
   return (
     <StyledForm onSubmit={handleSubmit}>
-      <div className="control">
-        <h2 className="container has-text-centered title is-2">이메일 인증</h2>
-      </div>
-      <p className="is-size-1">&nbsp;</p>
       <div className="p-2 mt-2">
         <p style={{ fontSize: FontSize.normal, fontWeight: FontWeight.bolder }}>
           메일을 받지 못하셨나요..?

--- a/src/components/member/JoinForm.js
+++ b/src/components/member/JoinForm.js
@@ -119,8 +119,6 @@ const JoinForm = ({ setFormSubmitted }) => {
 
   return (
     <StyledForm onSubmit={handleSubmit}>
-      <p className="container has-text-centered title is-2">회원가입</p>
-      <DevideLine space="small" color="none" />
       <label className="label">이메일</label>
       <IconInput
         name="email"

--- a/src/pages/JoinPage.js
+++ b/src/pages/JoinPage.js
@@ -2,6 +2,7 @@ import { Columns, Container, Hero } from 'react-bulma-components';
 
 import EmailValidationForm from '../components/email/EmailValidationForm';
 import JoinForm from '../components/member/JoinForm';
+import PageTitle from '../components/common/PageTitle';
 import styled from '@emotion/styled';
 import { useState } from 'react';
 
@@ -9,25 +10,28 @@ const JoinPage = () => {
   const [formSubmitted, setFormSubmitted] = useState(false);
 
   return (
-    <Hero size={'fullheight'}>
-      <StyledHeroBody>
-        <Container>
-          <Columns.Column
-            className="is-half-desktop is-offset-3-desktop is-8-tablet is-offset-2-tablet is-fullwidth-mobile"
-            style={{
-              display: 'flex',
-              justifyContent: 'center',
-            }}
-          >
-            {formSubmitted ? (
-              <EmailValidationForm />
-            ) : (
-              <JoinForm setFormSubmitted={setFormSubmitted} />
-            )}
-          </Columns.Column>
-        </Container>
-      </StyledHeroBody>
-    </Hero>
+    <>
+      <PageTitle>{formSubmitted ? '이메일 인증' : '회원가입'}</PageTitle>
+      <Hero size={'small'}>
+        <StyledHeroBody>
+          <Container>
+            <Columns.Column
+              className="is-half-desktop is-offset-3-desktop is-8-tablet is-offset-2-tablet is-fullwidth-mobile"
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+              }}
+            >
+              {formSubmitted ? (
+                <EmailValidationForm />
+              ) : (
+                <JoinForm setFormSubmitted={setFormSubmitted} />
+              )}
+            </Columns.Column>
+          </Container>
+        </StyledHeroBody>
+      </Hero>
+    </>
   );
 };
 

--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -6,6 +6,7 @@ import AnimatedIcon from '../components/icons/AnimatedIcon';
 import Buttons from '../components/common/Buttons';
 import { Colors } from '../styles';
 import IconInput from '../components/common/IconInput';
+import PageTitle from '../components/common/PageTitle';
 import Swal from 'sweetalert2';
 import { TOKEN_INFO } from '../constants/tokens';
 import { loginState } from '../state/loginState';
@@ -61,7 +62,8 @@ const LoginPage = () => {
 
   return (
     <>
-      <Hero size={'medium'}>
+      <PageTitle>로그인</PageTitle>
+      <Hero size={'small'}>
         <StyledHeroBody>
           <Container>
             <Columns.Column
@@ -72,10 +74,6 @@ const LoginPage = () => {
               }}
             >
               <StyledForm onSubmit={handleSubmit}>
-                <div className="control">
-                  <h2 className="container has-text-centered title is-2">로그인</h2>
-                </div>
-                <p className="is-size-3">&nbsp;</p>
                 <div className="control">
                   <label className="label">이메일</label>
                   <IconInput


### PR DESCRIPTION

**왜**

- 폼 중심의 페이지에서 타이틀 부분이 위치가 모두 달라 보기가 싫었다.

**한 것**

- 타이틀 컴포넌트 분리 후 폼 페이지에 위에 적용하여 폼 UI와 분리 