### PR TITLE
비밀번호 찾기 페이지 UI 및 기능 추가

### DIFF
--- a/src/api/memberApi.js
+++ b/src/api/memberApi.js
@@ -1,4 +1,4 @@
-import { requestForAll } from './config';
+import { requestForAll, requestForAuth } from './config';
 
 const memberApi = 'api/members';
 
@@ -12,4 +12,16 @@ export const onJoin = joinForm => {
 
 export const onCheckNicknameDuplication = nickname => {
   return requestForAll.get(memberApi + '/nickname', { params: { nickname } });
+};
+
+export const onChangePasswordWithVerifiedEmailByNoAuthUser = (email, password) => {
+  return requestForAll.put(memberApi + '/password/noauth', { email: email, password: password });
+};
+
+export const onChangePasswordByMember = password => {
+  return requestForAuth.put(memberApi + '/password', { password: password });
+};
+
+export const onSelectMemberByEmail = email => {
+  return requestForAll.get(memberApi + `/email?email=${email}`);
 };

--- a/src/components/email/EmailValidationForm.js
+++ b/src/components/email/EmailValidationForm.js
@@ -9,6 +9,7 @@ import AnimatedIcon from '../icons/AnimatedIcon';
 import Buttons from '../common/Buttons';
 import { Columns } from 'react-bulma-components';
 import CountdownTimer from '../common/CountDownTimer';
+import { ERROR_CODE } from '../../constants/status';
 import { FontWeight } from '../../styles/font';
 import IconInput from '../common/IconInput';
 import Swal from 'sweetalert2';
@@ -69,7 +70,20 @@ const EmailValidationForm = ({ onSuccess, isJoinRequest = false, email, setEmail
     }
     setCurrentTime(new Date().getTime());
     setIsFirstRequest(false);
-    onRequestEmailCode(values.email);
+    onRequestEmailCode(values.email).catch(error => {
+      if (error.code === ERROR_CODE.BAD_REQUEST) {
+        Swal.fire({
+          icon: 'warning',
+          text: error.details,
+        });
+      }
+      if (error.code === ERROR_CODE.INTERNAL_SERVER_ERROR) {
+        Swal.fire({
+          icon: 'error',
+          text: '알 수없는 이유로 이메일 인증에 실패했습니다',
+        });
+      }
+    });
     Swal.fire({
       icon: 'success',
       text: '인증 코드를 발송했어요!',

--- a/src/components/email/EmailValidationForm.js
+++ b/src/components/email/EmailValidationForm.js
@@ -1,32 +1,42 @@
 import * as Yup from 'yup';
 
 import { Colors, FontSize } from '../../styles';
+import { EMAIL, EMAIL_CODE } from '../../constants/business';
 import { onRequestEmailCode, onVerifyEmailCode } from '../../api/emailApi';
+import { useEffect, useState } from 'react';
 
 import AnimatedIcon from '../icons/AnimatedIcon';
 import Buttons from '../common/Buttons';
 import { Columns } from 'react-bulma-components';
 import CountdownTimer from '../common/CountDownTimer';
-import { EMAIL_CODE } from '../../constants/business';
 import { FontWeight } from '../../styles/font';
 import IconInput from '../common/IconInput';
 import Swal from 'sweetalert2';
-import { currentJoinFormState } from '../../state/joinState';
-import { onJoin } from '../../api/memberApi';
 import styled from '@emotion/styled';
 import { useFormik } from 'formik';
-import { useRecoilState } from 'recoil';
-import { useState } from 'react';
 
-const EmailValidationForm = () => {
-  const [currentJoinForm, setCurrentJoinForm] = useRecoilState(currentJoinFormState);
+const EmailValidationForm = ({ onSuccess, isJoinRequest = false, email, setEmail }) => {
   const [currentTime, setCurrentTime] = useState(new Date().getTime());
+  const [isFirstRequest, setIsFirstRequest] = useState(true);
+
+  useEffect(() => {
+    if (isJoinRequest) {
+      setIsFirstRequest(false);
+    }
+  }, []);
+
   const initialValues = {
-    email: currentJoinForm.email,
+    email: isJoinRequest ? email : '',
     code: '',
   };
 
+  const EMAIL_VALIDATION = EMAIL.VALIDATION;
+
   const validationSchema = Yup.object().shape({
+    email: Yup.string()
+      .strict(true)
+      .matches(EMAIL_VALIDATION.REGEX, EMAIL_VALIDATION.MESSAGE)
+      .required(EMAIL_VALIDATION.REQUIRE),
     code: Yup.string()
       .strict(true)
       .length(EMAIL_CODE.LENGTH, EMAIL_CODE.MESSAGE)
@@ -39,30 +49,59 @@ const EmailValidationForm = () => {
     onSubmit: async (values, formikHelper) => {
       formikHelper.setStatus({ success: true });
       formikHelper.setSubmitting(false);
-      onVerifyEmailCode(values).then(() => {
-        setCurrentJoinForm;
-        onJoin(currentJoinForm)
-          .then(() => {
-            setCurrentJoinForm(undefined);
-            Swal.fire({
-              icon: 'success',
-              text: '회원가입 성공!',
-            }).then(() => {
-              window.location.href = '/';
-            });
-          })
-          .catch(error => {
-            Swal.fire({
-              icon: 'fail',
-              text: error.details || error.message || '회원가입 실패!',
-            });
+      setEmail && setEmail(values.email);
+      onVerifyEmailCode(values)
+        .then(() => {
+          onSuccess();
+        })
+        .catch(error => {
+          Swal.fire({
+            icon: 'error',
+            text: error.details || error.message,
           });
-      });
+        });
     },
   });
 
+  const handleSendEmailCodeButton = () => {
+    if (errors.email) {
+      return;
+    }
+    setCurrentTime(new Date().getTime());
+    setIsFirstRequest(false);
+    onRequestEmailCode(values.email);
+    Swal.fire({
+      icon: 'success',
+      text: '인증 코드를 발송했어요!',
+    });
+  };
+
   return (
     <StyledForm onSubmit={handleSubmit}>
+      <IconInput
+        disabled={isJoinRequest ? true : false}
+        type="text"
+        name="email"
+        autocomplete="off"
+        onChange={handleChange}
+        onBlur={handleBlur}
+        value={values.email}
+        placeholder="이메일 입력"
+        leftIconComponent={<AnimatedIcon.Email />}
+      />
+      <p
+        className="mt-3"
+        style={{ color: errors.email ? Colors.warningFirst : Colors.successFirst }}
+      >
+        &nbsp;{touched.email && (errors.email || '입력 완료')}
+      </p>
+      <p className="is-size-6">&nbsp;</p>
+      <div className="control">
+        <Buttons type={'button'} onClick={handleSendEmailCodeButton}>
+          {isFirstRequest ? '전송하기' : '재전송'}
+        </Buttons>
+      </div>
+      <p className="is-size-3">&nbsp;</p>
       <div className="p-2 mt-2">
         <p style={{ fontSize: FontSize.normal, fontWeight: FontWeight.bolder }}>
           메일을 받지 못하셨나요..?
@@ -78,40 +117,36 @@ const EmailValidationForm = () => {
         </SubDescription>
       </div>
       <br />
-      <IconInput
-        type="text"
-        name="code"
-        autocomplete="off"
-        onChange={handleChange}
-        onBlur={handleBlur}
-        value={values.code}
-        placeholder="인증코드를 입력해주세요."
-        leftIconComponent={<AnimatedIcon.Password />}
-      />
-      <p
-        className="mt-2"
-        style={{ color: errors.code ? Colors.warningFirst : Colors.successFirst }}
-      >
-        &nbsp;{touched.code && (errors.code || '입력 완료')}
-      </p>
-      <Columns className="is-mobile">
-        <Columns.Column className="is-half">
-          <CountdownTimer targetDate={currentTime + EMAIL_CODE.EXPIRATION_MILLS} />
-        </Columns.Column>
-        <Columns.Column className="is-half">
-          <a
-            onClick={() => {
-              setCurrentTime(new Date().getTime());
-              onRequestEmailCode(values.email);
-            }}
+      {!isFirstRequest && (
+        <>
+          <IconInput
+            type="text"
+            name="code"
+            autocomplete="off"
+            onChange={handleChange}
+            onBlur={handleBlur}
+            value={values.code}
+            placeholder="인증코드를 입력해주세요."
+            leftIconComponent={<AnimatedIcon.Password />}
+          />
+          <p
+            className="mt-3"
+            style={{ color: errors.code ? Colors.warningFirst : Colors.successFirst }}
           >
-            재전송
-          </a>
-        </Columns.Column>
-      </Columns>
-      <div className="control">
-        <Buttons type={'submit'}>인증하기</Buttons>
-      </div>
+            &nbsp;{touched.code && (errors.code || '입력 완료')}
+          </p>
+          <Columns className="is-mobile">
+            <Columns.Column className="is-half">
+              {!isFirstRequest && (
+                <CountdownTimer targetDate={currentTime + EMAIL_CODE.EXPIRATION_MILLS} />
+              )}
+            </Columns.Column>
+          </Columns>
+          <div className="control">
+            <Buttons type={'submit'}>인증하기</Buttons>
+          </div>
+        </>
+      )}
     </StyledForm>
   );
 };

--- a/src/components/member/ChangePasswordForm.js
+++ b/src/components/member/ChangePasswordForm.js
@@ -1,0 +1,141 @@
+import * as Yup from 'yup';
+
+import {
+  onChangePasswordByMember,
+  onChangePasswordWithVerifiedEmailByNoAuthUser,
+  onSelectMemberByEmail,
+} from '../../api/memberApi';
+
+import AnimatedIcon from '../icons/AnimatedIcon';
+import Buttons from '../common/Buttons';
+import { Colors } from '../../styles';
+import IconInput from '../common/IconInput';
+import { PASSWORD } from '../../constants/business';
+import Swal from 'sweetalert2';
+import styled from '@emotion/styled';
+import { useFormik } from 'formik';
+import { useQuery } from 'react-query';
+
+const ChangePasswordForm = ({ purpose, authRequest, email }) => {
+  const initialValues = {
+    password: '',
+    checkPassword: '',
+  };
+
+  const PASSWORD_VALIDATION = PASSWORD.VALIDATION;
+
+  useQuery('EMAIL', () => onSelectMemberByEmail(email), {
+    onError: error => {
+      Swal.fire({
+        icon: 'warning',
+        text: error.details || error.message,
+        timer: 1000,
+      }).then(() => {
+        setTimeout(() => (window.location.href = '/'), 50);
+      });
+    },
+  });
+
+  const validationSchema = Yup.object().shape({
+    password: Yup.string()
+      .required(PASSWORD_VALIDATION.REQUIRE)
+      .matches(PASSWORD_VALIDATION.REGEX, PASSWORD_VALIDATION.MESSAGE),
+    checkPassword: Yup.string()
+      .oneOf([Yup.ref('password'), null], '비밀번호가 일치하지 않습니다.')
+      .required('확인 비밀번호를 입력해주세요.'),
+  });
+
+  const { errors, handleBlur, handleSubmit, handleChange, touched, values } = useFormik({
+    initialValues,
+    validationSchema,
+    onSubmit: async (values, formikHelper) => {
+      try {
+        const changePasswordCallBack = authRequest
+          ? () => onChangePasswordByMember(values.password)
+          : () =>
+              onChangePasswordWithVerifiedEmailByNoAuthUser(email, values.password).then(() => {
+                setTimeout(() => (window.location.href = '/login'), 200);
+              });
+        changePasswordCallBack().then(() => {
+          Swal.fire({
+            icon: 'success',
+            text: '비밀번호 변경 성공',
+          });
+        });
+        formikHelper.resetForm();
+        formikHelper.setStatus({ success: true });
+        formikHelper.setSubmitting(false);
+      } catch (error) {
+        Swal.fire({
+          icon: 'error',
+          text: '비밀번호 변경 실패',
+        });
+      }
+    },
+  });
+
+  const resolveRightIconComponent = val => {
+    return (
+      touched[val] &&
+      (!errors[val] ? (
+        <AnimatedIcon.CheckMark size={'large'} />
+      ) : (
+        <AnimatedIcon.WarningAlert size={'large'} />
+      ))
+    );
+  };
+
+  return (
+    <StyledForm onSubmit={handleSubmit}>
+      <label className="label">{purpose}</label>
+      <IconInput
+        id="password"
+        name="password"
+        type="password"
+        onChange={handleChange}
+        onBlur={handleBlur}
+        value={values.password}
+        autocomplete="off"
+        placeholder="사용하실 새 비밀번호를 입력하세요"
+        required
+        leftIconComponent={<AnimatedIcon.Password />}
+        rightIconComponent={resolveRightIconComponent('password')}
+      />
+      <p
+        className="m-2"
+        style={{ color: errors.password ? Colors.warningFirst : Colors.successFirst }}
+      >
+        &nbsp;{touched.password && (errors.password || '비밀번호 입력이 확인되었어요')}
+      </p>
+      <label className="label">비밀번호 확인</label>
+      <IconInput
+        name="checkPassword"
+        type="password"
+        onChange={handleChange}
+        onBlur={handleBlur}
+        value={values.checkPassword}
+        autocomplete="off"
+        placeholder="비밀번호를 확인해주세요"
+        required
+        leftIconComponent={<AnimatedIcon.Password />}
+        rightIconComponent={resolveRightIconComponent('checkPassword')}
+      />
+      <p
+        className="m-2"
+        style={{
+          color: errors.checkPassword ? Colors.warningFirst : Colors.successFirst,
+        }}
+      >
+        &nbsp;
+        {touched.checkPassword && (errors.checkPassword || '비밀번호 입력이 확인되었어요')}
+      </p>
+      <Buttons type={'submit'}>비밀번호 변경</Buttons>
+    </StyledForm>
+  );
+};
+
+const StyledForm = styled.form`
+  width: 100%;
+`;
+
+export default ChangePasswordForm;

--- a/src/components/member/JoinForm.js
+++ b/src/components/member/JoinForm.js
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 import AnimatedIcon from '../icons/AnimatedIcon';
 import Buttons from '../common/Buttons';
 import { Columns } from 'react-bulma-components';
+import { EMAIL } from '../../constants/business';
 import IconInput from '../common/IconInput';
 import Swal from 'sweetalert2';
 import { currentJoinFormState } from '../../state/joinState';
@@ -28,11 +29,13 @@ const JoinForm = ({ setFormSubmitted }) => {
     checkPassword: '',
   };
 
+  const EMAIL_VALIDATION = EMAIL.VALIDATION;
+
   const validationSchema = Yup.object().shape({
     email: Yup.string()
       .strict(true)
-      .email('이메일 형식으로 작성해주세요.')
-      .required('이메일을 입력해주세요.'),
+      .matches(EMAIL_VALIDATION.REGEX, EMAIL_VALIDATION.MESSAGE)
+      .required(EMAIL_VALIDATION.REQUIRE),
     nickname: Yup.string()
       .strict(true)
       .required('닉네임을 입력해주세요')

--- a/src/components/member/JoinForm.js
+++ b/src/components/member/JoinForm.js
@@ -1,12 +1,12 @@
 import * as Yup from 'yup';
 
 import { Colors, FontSize, Shadows } from '../../styles';
+import { EMAIL, PASSWORD } from '../../constants/business';
 import { useEffect, useState } from 'react';
 
 import AnimatedIcon from '../icons/AnimatedIcon';
 import Buttons from '../common/Buttons';
 import { Columns } from 'react-bulma-components';
-import { EMAIL } from '../../constants/business';
 import IconInput from '../common/IconInput';
 import Swal from 'sweetalert2';
 import { currentJoinFormState } from '../../state/joinState';
@@ -30,6 +30,7 @@ const JoinForm = ({ setFormSubmitted }) => {
   };
 
   const EMAIL_VALIDATION = EMAIL.VALIDATION;
+  const PASSWORD_VALIDATION = PASSWORD.VALIDATION;
 
   const validationSchema = Yup.object().shape({
     email: Yup.string()
@@ -41,11 +42,8 @@ const JoinForm = ({ setFormSubmitted }) => {
       .required('닉네임을 입력해주세요')
       .matches(/^[a-zA-Z0-9가-힣_]{2,10}$/, '2~10 글자의 문자를 입력해주세요'),
     password: Yup.string()
-      .required('비밀번호를 입력하세요')
-      .matches(
-        /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{4,16}$/,
-        '비밀번호는 4~16자의 대소영문자,숫자,특수문자를 포함해야 합니다',
-      ),
+      .required(PASSWORD_VALIDATION.REQUIRE)
+      .matches(PASSWORD_VALIDATION.REGEX, PASSWORD_VALIDATION.MESSAGE),
     checkPassword: Yup.string()
       .oneOf([Yup.ref('password'), null], '비밀번호가 일치하지 않습니다.')
       .required('확인 비밀번호를 입력해주세요.'),

--- a/src/constants/business.js
+++ b/src/constants/business.js
@@ -20,3 +20,11 @@ export const EMAIL = {
     REQUIRE: '이메일을 입력하세요',
   },
 };
+
+export const PASSWORD = {
+  VALIDATION: {
+    REGEX: /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{4,16}$/,
+    MESSAGE: '비밀번호는 4~16자의 대소영문자,숫자,특수문자를 포함해야 합니다.',
+    REQUIRE: '비밀번호를 입력하세요',
+  },
+};

--- a/src/constants/business.js
+++ b/src/constants/business.js
@@ -12,3 +12,11 @@ export const EMAIL_CODE = {
   MESSAGE: '올바른 인증 코드를 입력해주세요',
   EXPIRATION_MILLS: 1000 * 60 * 5,
 };
+
+export const EMAIL = {
+  VALIDATION: {
+    REGEX: /^[a-zA-Z\d]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]{2,3}$/,
+    MESSAGE: '올바른 이메일 형태로 입력하세요',
+    REQUIRE: '이메일을 입력하세요',
+  },
+};

--- a/src/pages/FindPasswordPage.js
+++ b/src/pages/FindPasswordPage.js
@@ -1,7 +1,51 @@
+import { Columns, Container, Hero } from 'react-bulma-components';
+
+import ChangePasswordForm from '../components/member/ChangePasswordForm';
+import EmailValidationForm from '../components/email/EmailValidationForm';
+import PageTitle from '../components/common/PageTitle';
+import { useState } from 'react';
+
 const FindPasswordPage = () => {
+  const [verified, setVerified] = useState(false);
+  const [email, setEmail] = useState();
+
+  const getEmailFromEmailForm = email => {
+    setEmail(email);
+  };
+
   return (
     <>
-      <p>비밀번호 찾기 페이지입니다.</p>
+      <PageTitle>
+        {!verified ? '사용하시던 이메일로 인증해주세요' : '비밀번호를 재설정합니다'}
+      </PageTitle>
+      <Hero size={'small'}>
+        <Hero.Body>
+          <Container>
+            <p>&nbsp;</p>
+            <Columns.Column
+              className="is-half-desktop is-offset-3-desktop is-8-tablet is-offset-2-tablet is-fullwidth-mobile"
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+              }}
+            >
+              {verified ? (
+                <ChangePasswordForm
+                  purpose={'사용하실 새 비밀번호를 입력하세요'}
+                  authRequest={false}
+                  email={email}
+                />
+              ) : (
+                <EmailValidationForm
+                  onSuccess={() => setVerified(true)}
+                  isJoinRequest={false}
+                  setEmail={getEmailFromEmailForm}
+                />
+              )}
+            </Columns.Column>
+          </Container>
+        </Hero.Body>
+      </Hero>
     </>
   );
 };

--- a/src/pages/JoinPage.js
+++ b/src/pages/JoinPage.js
@@ -3,11 +3,35 @@ import { Columns, Container, Hero } from 'react-bulma-components';
 import EmailValidationForm from '../components/email/EmailValidationForm';
 import JoinForm from '../components/member/JoinForm';
 import PageTitle from '../components/common/PageTitle';
+import Swal from 'sweetalert2';
+import { currentJoinFormState } from '../state/joinState';
+import { onJoin } from '../api/memberApi';
 import styled from '@emotion/styled';
+import { useRecoilState } from 'recoil';
 import { useState } from 'react';
 
 const JoinPage = () => {
   const [formSubmitted, setFormSubmitted] = useState(false);
+  const [currentJoinForm, setCurrentJoinForm] = useRecoilState(currentJoinFormState);
+
+  const onSuccessJoin = async () => {
+    return onJoin(currentJoinForm)
+      .then(() => {
+        setCurrentJoinForm(undefined);
+        Swal.fire({
+          icon: 'success',
+          text: '회원가입 성공!',
+        }).then(() => {
+          window.location.href = '/';
+        });
+      })
+      .catch(error => {
+        Swal.fire({
+          icon: 'fail',
+          text: error.details || error.message || '회원가입 실패!',
+        });
+      });
+  };
 
   return (
     <>
@@ -23,7 +47,11 @@ const JoinPage = () => {
               }}
             >
               {formSubmitted ? (
-                <EmailValidationForm />
+                <EmailValidationForm
+                  onSuccess={onSuccessJoin}
+                  isJoinRequest={true}
+                  email={currentJoinForm.email}
+                />
               ) : (
                 <JoinForm setFormSubmitted={setFormSubmitted} />
               )}

--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -5,6 +5,7 @@ import { Columns, Container, Hero } from 'react-bulma-components';
 import AnimatedIcon from '../components/icons/AnimatedIcon';
 import Buttons from '../components/common/Buttons';
 import { Colors } from '../styles';
+import { EMAIL } from '../constants/business';
 import IconInput from '../components/common/IconInput';
 import PageTitle from '../components/common/PageTitle';
 import Swal from 'sweetalert2';
@@ -20,6 +21,8 @@ const LoginPage = () => {
   const [login, setLogin] = useRecoilState(loginState);
   const navigate = useNavigate();
 
+  const EMAIL_VALIDATION = EMAIL.VALIDATION;
+
   const initialValues = {
     email: '',
     password: '',
@@ -28,11 +31,10 @@ const LoginPage = () => {
   const validationSchema = Yup.object().shape({
     email: Yup.string()
       .strict(true)
-      .email('이메일 형식으로 작성해주세요.')
-      .required('이메일을 입력해주세요.'),
-    password: Yup.string()
-      .min(4, '최소 4글자 이상 입력하세요.')
-      .max(16, '최대 16글자 이하여야 합니다.')
+      .matches(EMAIL_VALIDATION.REGEX, EMAIL_VALIDATION.MESSAGE)
+      .required(EMAIL_VALIDATION.REQUIRE),
+    password:
+      Yup.string()
       .required('비밀번호를 입력해주세요.'),
   });
 

--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -1,6 +1,7 @@
 import * as Yup from 'yup';
 
 import { Columns, Container, Hero } from 'react-bulma-components';
+import { Link, useNavigate } from 'react-router-dom';
 
 import AnimatedIcon from '../components/icons/AnimatedIcon';
 import Buttons from '../components/common/Buttons';
@@ -14,7 +15,6 @@ import { loginState } from '../state/loginState';
 import { onLogin } from '../api/memberApi';
 import styled from '@emotion/styled';
 import { useFormik } from 'formik';
-import { useNavigate } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 
 const LoginPage = () => {
@@ -33,9 +33,7 @@ const LoginPage = () => {
       .strict(true)
       .matches(EMAIL_VALIDATION.REGEX, EMAIL_VALIDATION.MESSAGE)
       .required(EMAIL_VALIDATION.REQUIRE),
-    password:
-      Yup.string()
-      .required('비밀번호를 입력해주세요.'),
+    password: Yup.string().required('비밀번호를 입력해주세요.'),
   });
 
   const { errors, handleBlur, handleSubmit, handleChange, touched, values } = useFormik({
@@ -124,21 +122,20 @@ const LoginPage = () => {
                   <p style={{ color: errors.password ? Colors.warningFirst : Colors.successFirst }}>
                     &nbsp;{touched.password && (errors.password || '비밀번호 입력이 확인되었어요.')}
                   </p>
-                  <p className="is-size-6">&nbsp;</p>
+                  <p className="is-size-7">&nbsp;</p>
                 </div>
                 <div className="control">
                   <Buttons type={'submit'}>로그인</Buttons>
-                  <p className="is-size-7">&nbsp;</p>
-                  <div className="columns">
-                    <div className="column is-7">
-                      비밀번호 기억안나요!
-                      <a href="/findpassword">비밀번호찾기</a>
-                    </div>
-                    <div className="column is-7">
-                      아이디가 없어요!
-                      <a href="/join">회원가입</a>
-                    </div>
-                  </div>
+                  <p className="is-size-3">&nbsp;</p>
+                  <Columns className="is-mobile has-text-centered is-size-5-desktop is-size-6-mobile">
+                    <Columns.Column className="is-5">
+                      <Link to={'/findpassword'}>비밀번호찾기</Link>
+                    </Columns.Column>
+                    <Columns.Column className="is-2 has-text-link">|</Columns.Column>
+                    <Columns.Column className="is-5">
+                      <Link to={'/join'}>회원가입</Link>
+                    </Columns.Column>
+                  </Columns>
                 </div>
               </StyledForm>
             </Columns.Column>


### PR DESCRIPTION
resolves #87 

<br>

### 추가 및 개선 사항

**기존 이메일 인증 폼에 회원가입 동작이 종속되어있었던 부분을 분리**

- 이메일 인증 성공 시의 필요한 이벤트를 부모 컴포넌트에서 받아와서 동작시킬 수 있도록 변경

<br>

**비밀번호 잊은 사용자를 위한 비밀번호 변경 폼 및 변경 UI 추가**

- 비밀번호 찾기 페이지로 이동 시 먼저 이메일 인증을 수행할 수 있도록 함
- 이메일 인증에 성공한 경우 => (회원이 아니면 메인페이지로 리다이렉트) => 비밀번호 변경 폼으로 이동 



<br>


![image](https://user-images.githubusercontent.com/76927397/175467763-0848abaf-c1ed-435a-8d77-2b83d552f83d.png)

<br>

![image](https://user-images.githubusercontent.com/76927397/175467816-ca0ce5a1-0783-4886-b839-81bcbbcd2067.png)
