### PR TITLE
헤더바 로고 추가

### DIFF
--- a/src/assets/logos/Font.js
+++ b/src/assets/logos/Font.js
@@ -1,22 +1,25 @@
+import { Media } from '../../styles';
+import styled from '@emotion/styled';
+
 // 글씨와 글씨 왼쪽 작은 로고
-const Font = ({ size }) => {
+const FontLogo = ({ width, height }) => {
   return (
-    <svg
+    <StyledSvg
       version="1.1"
-      id="Layer_1"
+      id="FontLogo"
       xmlns="http://www.w3.org/2000/svg"
       x="0px"
       y="0px"
-      width={size}
-      height={size}
-      viewBox="0 0 455 116"
+      width={width}
+      height={height}
+      viewBox="0 0 600 110"
       enableBackground="new 0 0 455 116"
       xmlSpace="preserve"
     >
       <image
         id="image0"
-        width="455"
-        height="116"
+        // width={width}
+        // height={height}
         x="0"
         y="0"
         href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAccAAAB0CAYAAADw1fndAAAABGdBTUEAALGPC/xhBQAAACBjSFJN
@@ -457,8 +460,18 @@ DOJfDv8f+1svgBQYrogAAAAldEVYdGRhdGU6Y3JlYXRlADIwMjItMDYtMjVUMDI6MTM6MzkrMDA6
 MDBAh3oIAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDIyLTA2LTI1VDAyOjEzOjM5KzAwOjAwMdrCtAAA
 AABJRU5ErkJggg=="
       />
-    </svg>
+    </StyledSvg>
   );
 };
 
-export default Font;
+const StyledSvg = styled.svg`
+  width: ${({ width }) => width + 'px'};
+  height: ${({ height }) => height + 'px'};
+
+  @media ${Media.mobile} {
+    width: ${({ width }) => width / 2.3 + 'px'};
+    height: ${({ height }) => height / 2.3 + 'px'};
+  }
+`;
+
+export default FontLogo;

--- a/src/components/header/HeaderBar.js
+++ b/src/components/header/HeaderBar.js
@@ -3,6 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 
+import FontLogo from '../../assets/logos/Font';
 import { FontSize } from '../../styles/font';
 import HamburgerSideBar from './HamburgerSideBar';
 import HeaderSwitcher from './HeaderSwitcher';
@@ -64,7 +65,7 @@ const HeaderBar = () => {
             to={'/'}
             onClick={handleLinkClick}
           >
-            로고
+            <StyleFontLogo width="200" height="35" />
           </Link>
           <Navbar.Burger
             style={{ zIndex: '2' }}
@@ -162,6 +163,27 @@ const CenterSwitchContainer = styled(StyledLogo)`
     margin-bottom: 0;
   }
   @media ${Media.mobile} {
+    margin-top: -0.5rem;
+    margin-bottom: 0;
+  }
+`;
+
+const StyleFontLogo = styled(FontLogo)`
+  font-size: ${FontSize.large};
+  @media ${Media.desktop} {
+    width: 180;
+    margin-top: -0.5rem;
+    margin-bottom: 0;
+  }
+  @media ${Media.tablet} {
+    width: 180;
+    height: 40;
+    margin-top: -0.5rem;
+    margin-bottom: 0;
+  }
+  @media ${Media.mobile} {
+    width: 150;
+    height: 30;
     margin-top: -0.5rem;
     margin-bottom: 0;
   }


### PR DESCRIPTION
resolves #144 

### **완료된 사항**
- viewBox로 로고 전체 크기가 고정되어 고정 값을 주었음.
- width, height 가 svg와 image에 함께 적용되어 모바일 수정이 어려워 image width, height 값을 주석 처리
- 헤더바 로고 추가

### **수정해야할 사항**
- 모바일 햄버거 메뉴 실행시 로고가 블러처리가 안됨.
- 모바일 햄버거 메뉴 실행 후 화면 클릭시 로고가 눌리는 점 수정해야함.